### PR TITLE
test(refair-server): add unit tests

### DIFF
--- a/refair-server/requirements.txt
+++ b/refair-server/requirements.txt
@@ -1,4 +1,5 @@
 pytest
+pytest-mock
 coverage
 flask
 werkzeug

--- a/refair-server/test_REFAIR.py
+++ b/refair-server/test_REFAIR.py
@@ -1,4 +1,6 @@
-from REFAIR import intersection
+import pandas as pd
+from io import StringIO
+from REFAIR import intersection, feature_extraction
 
 
 class TestIntersection:
@@ -43,3 +45,120 @@ class TestIntersection:
 
         assert result == ["Feature1"]
 
+class TestFeatureExtraction:
+
+    def test_feature_extraction_with_no_tasks(self, mocker):
+        domains_mapping_csv_data = 'Domain,Feature\n' + \
+        'health,age\n'
+        domains_mapping_mock = pd.read_csv(StringIO(domains_mapping_csv_data))
+        tasks_mapping_csv_data = 'Task,Feature\n' + \
+        'clustering,age\n'
+        tasks_mapping_mock = pd.read_csv(StringIO(tasks_mapping_csv_data))
+
+        mocker.patch('REFAIR.domains_mapping', domains_mapping_mock)
+        mocker.patch('REFAIR.tasks_mapping', tasks_mapping_mock)
+
+        domain = 'Health'
+        mltasks = []
+
+        result = feature_extraction(domain, mltasks)
+
+        assert result == {}
+
+    def test_feature_extraction_with_no_matching_features(self, mocker):
+        domains_mapping_csv_data = 'Domain,Feature\n' + \
+        'health,age\n'
+        domains_mapping_mock = pd.read_csv(StringIO(domains_mapping_csv_data))
+        tasks_mapping_csv_data = 'Task,Feature\n' + \
+        'clustering,author\n'
+        tasks_mapping_mock = pd.read_csv(StringIO(tasks_mapping_csv_data))
+
+        mocker.patch('REFAIR.domains_mapping', domains_mapping_mock)
+        mocker.patch('REFAIR.tasks_mapping', tasks_mapping_mock)
+
+        domain = 'Health'
+        mltasks = ['Clustering']
+
+        result = feature_extraction(domain, mltasks)
+
+        assert result == {
+            'Clustering': []
+        }
+
+    def test_feature_extraction_with_single_task(self, mocker):
+        domains_mapping_csv_data = 'Domain,Feature\n' + \
+        'health,age\n' + \
+        'health,ethnicity\n' + \
+        'health,gender\n' + \
+        'information systems,age\n' + \
+        'information systems,brand ownership\n' + \
+        'information systems,gay-friendliness\n' + \
+        'law,age\n' + \
+        'law,ethnicity\n' + \
+        'law,gender\n'
+        domains_mapping_mock = pd.read_csv(StringIO(domains_mapping_csv_data))
+        tasks_mapping_csv_data = 'Task,Feature\n' + \
+        'clustering,age\n' + \
+        'clustering,author\n' + \
+        'clustering,ethnicity\n' + \
+        'data summarization,age\n' + \
+        'data summarization,caste\n' + \
+        'data summarization,gender\n'
+        tasks_mapping_mock = pd.read_csv(StringIO(tasks_mapping_csv_data))
+
+        mocker.patch('REFAIR.domains_mapping', domains_mapping_mock)
+        mocker.patch('REFAIR.tasks_mapping', tasks_mapping_mock)
+
+        domain = 'Health'
+        mltasks = ['Clustering']
+
+        result = feature_extraction(domain, mltasks)
+
+        assert result == {
+            'Clustering': [
+                'age',
+                'ethnicity'
+            ]
+        }
+
+    def test_feature_extraction_with_multiple_tasks(self, mocker):
+        domains_mapping_csv_data = 'Domain,Feature\n' + \
+        'health,age\n' + \
+        'health,ethnicity\n' + \
+        'health,gender\n' + \
+        'information systems,age\n' + \
+        'information systems,brand ownership\n' + \
+        'information systems,gay-friendliness\n' + \
+        'law,age\n' + \
+        'law,ethnicity\n' + \
+        'law,gender\n'
+        domains_mapping_mock = pd.read_csv(StringIO(domains_mapping_csv_data))
+        tasks_mapping_csv_data = 'Task,Feature\n' + \
+        'classification,age\n' + \
+        'classification,geography\n' + \
+        'classification,race\n' + \
+        'clustering,age\n' + \
+        'clustering,author\n' + \
+        'clustering,ethnicity\n' + \
+        'data summarization,age\n' + \
+        'data summarization,caste\n' + \
+        'data summarization,gender\n'
+        tasks_mapping_mock = pd.read_csv(StringIO(tasks_mapping_csv_data))
+
+        mocker.patch('REFAIR.domains_mapping', domains_mapping_mock)
+        mocker.patch('REFAIR.tasks_mapping', tasks_mapping_mock)
+
+        domain = 'Health'
+        mltasks = ['Classification', 'Clustering']
+
+        result = feature_extraction(domain, mltasks)
+
+        assert result == {
+            'Classification' : [
+                'age'
+            ],
+            'Clustering': [
+                'age',
+                'ethnicity'
+            ]
+        }

--- a/refair-server/test_REFAIR.py
+++ b/refair-server/test_REFAIR.py
@@ -1,0 +1,45 @@
+from REFAIR import intersection
+
+
+class TestIntersection:
+    
+    def test_intersection_with_both_lists_empty(self):
+        first_list = []
+        second_list = []
+
+        result = intersection(first_list, second_list)
+
+        assert result == []
+
+    def test_intersection_with_first_list_empty(self):
+        first_list = []
+        second_list = ["Feature1", "Feature2"]
+
+        result = intersection(first_list, second_list)
+
+        assert result == []
+
+    def test_intersection_with_second_list_empty(self):
+        first_list = ["Feature1", "Feature2"]
+        second_list = []
+
+        result = intersection(first_list, second_list)
+
+        assert result == []
+
+    def test_intersection_with_no_element_in_common(self):
+        first_list = ["Feature1", "Feature2"]
+        second_list = ["Feature3"]
+
+        result = intersection(first_list, second_list)
+
+        assert result == []
+
+    def test_intersection_with_one_element_in_common(self):
+        first_list = ["Feature1", "Feature2"]
+        second_list = ["Feature1"]
+
+        result = intersection(first_list, second_list)
+
+        assert result == ["Feature1"]
+

--- a/refair-server/test_app.py
+++ b/refair-server/test_app.py
@@ -1,0 +1,83 @@
+import pandas as pd
+from io import BytesIO
+
+
+class TestLoadStories: 
+    def test_load_stories_with_no_file_in_request(self, client):
+        response = client.post(
+            path='/storiesload'
+        )
+        assert response.status_code == 200
+        assert response.json == {
+            'status': 'failure',
+            'motivation': 'No file \"stories.xlsx\" loaded'
+        }
+
+    def test_load_stories_with_not_allowed_file(self, client):
+        data = {
+            'stories': (BytesIO(b"Some data."), 'stories.txt')
+        }
+        response = client.post(
+            path='/storiesload',
+            content_type='multipart/form-data',
+            data=data
+        )
+        assert response.status_code == 200
+        assert response.json == {
+            'status': 'failure',
+            'motivation': 'No file \"stories.xlsx\" loaded'
+        }
+
+    def test_load_stories_without_user_story_column(self, client):
+        stories = pd.DataFrame({
+            'My stories': [
+                'First user story.',
+                'Second user story.',
+                'Third user story.'
+            ]
+        })
+        buffer = BytesIO()
+        stories.to_excel(buffer, index=False)
+        buffer.seek(0)
+        data = {
+            'stories': (buffer, 'file_without_user_story_column.xlsx')
+        }
+        response = client.post(
+            path='/storiesload', 
+            content_type='multipart/form-data',
+            data=data
+        )
+        assert response.status_code == 200
+        assert response.json == {
+            'status': 'failure',
+            'motivation': "No column \"User Story\" found"
+        }
+
+    def test_load_stories_with_user_story_column(self, client):
+        stories = pd.DataFrame({
+            'User Story': [
+                'First user story.',
+                'Second user story.',
+                'Third user story.'
+            ]
+        })
+        buffer = BytesIO()
+        stories.to_excel(buffer, index=False)
+        buffer.seek(0)
+        data = {
+            'stories': (buffer, 'file_with_user_story_column.xlsx')
+        }
+        response = client.post(
+            path='/storiesload', 
+            content_type='multipart/form-data',
+            data=data
+        )
+        assert response.status_code == 200
+        assert response.json == {
+            'status': 'success',
+            'stories': [
+                'First user story.',
+                'Second user story.',
+                'Third user story.'
+            ]
+        }

--- a/refair-server/test_app.py
+++ b/refair-server/test_app.py
@@ -1,3 +1,4 @@
+import json
 import pandas as pd
 from io import BytesIO
 
@@ -178,4 +179,113 @@ class TestAnalysis:
                 'Feature_1': 1,
                 'Feature_2': 2
             }
+        }
+
+class TestReportStories:
+    def test_report_stories_with_get_request_not_allowed(self, client):
+        response = client.get(
+            path='/reportStories'
+        )
+        assert response.status_code == 200
+        assert response.data.decode() == 'Not Allowed'
+
+    def test_report_stories_with_empty_data(self, client):
+        response = client.post(
+            path='/reportStories', 
+            data={}
+        )
+        assert response.status_code == 400
+
+    def test_report_stories_with_single_user_story(self, client, mocker):
+        story = 'A user story that focuses on Task_A and Task_B in the context of ExampleDomain.'
+        return_domain = 'ExampleDomain'
+        return_ml_tasks = ['Task_A', 'Task_B']
+        return_features = {
+            'Task_A': [
+                'Feature_1',
+                'Feature_2'
+            ],
+            'Task_B': [
+                'Feature_2'
+            ]
+        }
+        mocker.patch('app.getDomain', return_value=return_domain)
+        mocker.patch('app.getMLTask', return_value=return_ml_tasks)
+        mocker.patch('app.feature_extraction', return_value=return_features)
+
+        response = client.post(
+            path='/reportStories',
+            data={
+                'stories': json.dumps([
+                    story
+                ])
+            }
+        )
+
+        # Convert response data to a JSON object
+        response_data = json.loads(response.get_data(as_text=True).replace("\'", "\""))
+
+        assert response.status_code == 200
+        assert response.content_type == 'application/json'
+        assert response.headers['Content-Disposition'] == 'attachment;filename=zones.geojson'
+        assert len(response_data) == 1
+        assert response_data[0] == {
+            'story': story,
+            'domain': return_domain,
+            'tasks': return_ml_tasks,
+            'features': return_features
+        }
+
+    def test_report_stories_with_two_user_stories(self, client, mocker):
+        stories = [
+            'A user story that focuses on Task_A and Task_B in the context of ExampleDomain_1.',
+            'A user story that focuses on Task_C in the context of ExampleDomain_2.'
+        ]
+        return_domain = ['ExampleDomain_1', 'ExampleDomain_2']
+        return_ml_tasks = [['Task_A', 'Task_B'], ['Task_C']]
+        return_features = [
+            {
+                'Task_A': [
+                    'Feature_1',
+                    'Feature_2'
+                ],
+                'Task_B': [
+                    'Feature_2'
+                ]
+            },
+            {
+                'Task_C': [
+                    'Feature_3'
+                ]
+            }
+        ]
+        mocker.patch('app.getDomain', side_effect=return_domain)
+        mocker.patch('app.getMLTask', side_effect=return_ml_tasks)
+        mocker.patch('app.feature_extraction', side_effect=return_features)
+
+        response = client.post(
+            path='/reportStories',
+            data={
+                'stories': json.dumps(stories)
+            }
+        )
+
+        # Convert response data to a JSON object
+        response_data = json.loads(response.get_data(as_text=True).replace("\'", "\""))
+
+        assert response.status_code == 200
+        assert response.content_type == 'application/json'
+        assert response.headers['Content-Disposition'] == 'attachment;filename=zones.geojson'
+        assert len(response_data) == 2
+        assert response_data[0] == {
+            'story': stories[0],
+            'domain': return_domain[0],
+            'tasks': return_ml_tasks[0],
+            'features': return_features[0]
+        }
+        assert response_data[1] == {
+            'story': stories[1],
+            'domain': return_domain[1],
+            'tasks': return_ml_tasks[1],
+            'features': return_features[1]
         }


### PR DESCRIPTION
This pull request introduces an initial set of unit tests for the back-end of ReFair-App. 

It's by no means an exhaustive regression test suite, but it's better than nothing.